### PR TITLE
Added github actions and updated build from SimpleMC/mc-kotlin-plugin-template

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -1,0 +1,25 @@
+name: PR
+on: pull_request
+
+jobs:
+  build:
+    name: Gradle Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-caches-
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: build

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -33,4 +33,4 @@ jobs:
         with:
           args: |
             build/libs/simpleannounce-${{ steps.format-version.outputs.replaced }}.jar
-            build/libs/simpleannounce-${{ steps.format-version.outputs.replaced }}-all.jar
+            build/libs/simpleannounce-${{ steps.format-version.outputs.replaced }}-nokt.jar

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,36 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'release-*'
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Gradle Build
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: build
+      - name: Extract version
+        uses: frabert/replace-string-action@master
+        id: format-version
+        with:
+          pattern: 'refs/tags/release-([0-9]+.[0-9]+.[0-9]+)'
+          string: ${{ github.ref }}
+          replace-with: '$1'
+      - name: Release
+        uses: docker://antonyurchenko/git-release:v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRAFT_RELEASE: "true"
+          ALLOW_TAG_PREFIX: "true"
+        with:
+          args: |
+            build/libs/simpleannounce-${{ steps.format-version.outputs.replaced }}.jar
+            build/libs/simpleannounce-${{ steps.format-version.outputs.replaced }}-all.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## Unreleased
+### Added
+- CHANGELOG
+- Github Actions for build and automated releases
+
+### Changed
+- Adopt semver
+- Kotlin rewrite
+- Target MC version 1.15
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,9 +116,11 @@ tasks {
     register<ShadowJar>("nokt") {
         minimize()
         archiveClassifier.set("nokt")
+        from(sourceSets.main.get().output)
+        configurations = listOf(project.configurations.runtimeClasspath.get())
 
         dependencies {
-            exclude("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+            exclude(dependency("org.jetbrains.*:"))
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,83 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import pl.allegro.tech.build.axion.release.domain.hooks.HookContext
+import pl.allegro.tech.build.axion.release.domain.hooks.HooksConfig
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 plugins {
-    kotlin("jvm") version "1.3.31"
-    id("com.github.johnrengelman.shadow") version "4.0.3"
+    kotlin("jvm") version "1.3.61"
+    id("com.github.johnrengelman.shadow") version "5.2.0"
+    id("pl.allegro.tech.build.axion-release") version "1.10.3"
+    id("org.jlleitschuh.gradle.ktlint") version "9.1.1"
 }
 
+val repoRef = "SimpleMC\\/SimpleAnnounce"
+val mcApiVersion = "1.15"
+
 group = "org.simplemc"
-version = "1.15-SNAPSHOT"
+version = scmVersion.version
+
+scmVersion {
+    hooks(closureOf<HooksConfig> {
+        pre(
+            "fileUpdate",
+            mapOf(
+                "file" to "src/main/resources/plugin.yml",
+                "pattern" to KotlinClosure2<String, HookContext, String>({ v, _ -> "version: $v\\napi-version: \".+\"" }),
+                "replacement" to KotlinClosure2<String, HookContext, String>({ v, _ -> "version: $v\napi-version: \"$mcApiVersion\"" })
+            )
+        )
+        // "normal" changelog update--changelog already contains a history
+        pre(
+            "fileUpdate",
+            mapOf(
+                "file" to "CHANGELOG.md",
+                "pattern" to KotlinClosure2<String, HookContext, String>({ v, _ ->
+                    "\\[Unreleased\\]([\\s\\S]+?)\\n(?:^\\[Unreleased\\]: https:\\/\\/github\\.com\\/$repoRef\\/compare\\/release-$v\\.\\.\\.HEAD\$([\\s\\S]*))?\\z"
+                }),
+                "replacement" to KotlinClosure2<String, HookContext, String>({ v, c ->
+                    """
+                        \[Unreleased\]
+                        
+                        ## \[$v\] - ${currentDateString()}$1
+                        \[Unreleased\]: https:\/\/github\.com\/$repoRef\/compare\/release-$v...HEAD
+                        \[$v\]: https:\/\/github\.com\/$repoRef\/compare\/release-${c.previousVersion}...release-$v$2
+                    """.trimIndent()
+                })
+            )
+        )
+        // first-time changelog update--changelog has only unreleased info
+        pre(
+            "fileUpdate",
+            mapOf(
+                "file" to "CHANGELOG.md",
+                "pattern" to KotlinClosure2<String, HookContext, String>({ v, _ ->
+                    "Unreleased([\\s\\S]+?\\nand this project adheres to \\[Semantic Versioning\\]\\(https:\\/\\/semver\\.org\\/spec\\/v2\\.0\\.0\\.html\\).)\\s\\z"
+                }),
+                "replacement" to KotlinClosure2<String, HookContext, String>({ v, c ->
+                    """
+                        \[Unreleased\]
+                        
+                        ## \[$v\] - ${currentDateString()}$1
+                        
+                        \[Unreleased\]: https:\/\/github\.com\/$repoRef\/compare\/release-$v...HEAD
+                        \[$v\]: https:\/\/github\.com\/$repoRef\/releases\/tag\/release-$v
+                    """.trimIndent()
+                })
+            )
+        )
+        pre("commit")
+    })
+}
+
+fun currentDateString() = OffsetDateTime.now(ZoneOffset.UTC).toLocalDate().format(DateTimeFormatter.ISO_DATE)
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 repositories {
     jcenter()
@@ -17,10 +87,20 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "1.15+")
+    compileOnly(group = "org.spigotmc", name = "spigot-api", version = "$mcApiVersion+")
+}
+
+ktlint {
+    // FIXME - ktlint bug(?): https://github.com/pinterest/ktlint/issues/527
+    disabledRules.set(listOf("import-ordering"))
 }
 
 tasks {
+    wrapper {
+        gradleVersion = "6.1.1"
+        distributionType = Wrapper.DistributionType.ALL
+    }
+
     withType<KotlinCompile> {
         kotlinOptions {
             jvmTarget = "1.8"
@@ -31,7 +111,7 @@ tasks {
         minimize()
     }
 
-    named("build") {
+    build {
         dependsOn(":shadowJar")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import pl.allegro.tech.build.axion.release.domain.hooks.HookContext
 import pl.allegro.tech.build.axion.release.domain.hooks.HooksConfig
 import java.time.OffsetDateTime
@@ -105,11 +106,23 @@ tasks {
         }
     }
 
+    // standard jar should be ready to go with all dependencies
     shadowJar {
         minimize()
+        archiveClassifier.set("")
+    }
+
+    // nokt jar without the kotlin runtime
+    register<ShadowJar>("nokt") {
+        minimize()
+        archiveClassifier.set("nokt")
+
+        dependencies {
+            exclude("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+        }
     }
 
     build {
-        dependsOn(":shadowJar")
+        dependsOn(":shadowJar", ":nokt")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import pl.allegro.tech.build.axion.release.domain.hooks.HookContext
 import pl.allegro.tech.build.axion.release.domain.hooks.HooksConfig
 import java.time.OffsetDateTime
@@ -101,13 +99,13 @@ tasks {
         distributionType = Wrapper.DistributionType.ALL
     }
 
-    withType<KotlinCompile> {
+    compileKotlin {
         kotlinOptions {
             jvmTarget = "1.8"
         }
     }
 
-    withType<ShadowJar> {
+    shadowJar {
         minimize()
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: SimpleAnnounce
 main: org.simplemc.simpleannounce.SimpleAnnounce
-version: 1.15.0
+version: 0.1.0
 api-version: "1.15"
 website: https://github.com/SimpleMC/SimpleAnnounce
 author: tajobe


### PR DESCRIPTION
Note that the "initial version" of 0.1.0 is there to be replaced by 1.0.0 as the start of a new release cycle using semver.

Currently, the release plugin knows that 1.0.0 is the next version:
```bash
$ ./gradlew currentVersion -q

Project version: 1.0.0-SNAPSHOT
```
...and a dryRun of the release process looks to take `0.1.0` -> `1.0.0`
```bash
$ ./gradlew release -Prelease.dryRun -q
DRY-RUN: uncommitted changes: false
Looking for uncommitted changes..
DRY-RUN: ahead of remote: false
Checking if branch is ahead of remote..
Checking for snapshot versions..
Replacing pattern "version: 0.1.0\napi-version: ".+"" with "version: 1.0.0
api-version: "1.15"" in /mnt/d/gitspace/smc/SimpleAnnounce/src/main/resources/plugin.yml
Replacing pattern "\[Unreleased\]([\s\S]+?)\n(?:^\[Unreleased\]: https:\/\/github\.com\/SimpleMC\/SimpleAnnounce\/compare\/release-0.1.0\.\.\.HEAD$([\s\S]*))?\z" with "\[Unreleased\]

## \[1.0.0\] - 2020-02-09$1
\[Unreleased\]: https:\/\/github\.com\/SimpleMC\/SimpleAnnounce\/compare\/release-1.0.0...HEAD
\[1.0.0\]: https:\/\/github\.com\/SimpleMC\/SimpleAnnounce\/compare\/release-0.1.0...release-1.0.0$2" in /mnt/d/gitspace/smc/SimpleAnnounce/CHANGELOG.md
Replacing pattern "Unreleased([\s\S]+?\nand this project adheres to \[Semantic Versioning\]\(https:\/\/semver\.org\/spec\/v2\.0\.0\.html\).)\s\z" with "\[Unreleased\]

## \[1.0.0\] - 2020-02-09$1

\[Unreleased\]: https:\/\/github\.com\/SimpleMC\/SimpleAnnounce\/compare\/release-1.0.0...HEAD
\[1.0.0\]: https:\/\/github\.com\/SimpleMC\/SimpleAnnounce\/releases\/tag\/release-1.0.0" in /mnt/d/gitspace/smc/SimpleAnnounce/CHANGELOG.md
DRY-RUN: commiting files matching [/mnt/d/gitspace/smc/SimpleAnnounce/src/main/resources/plugin.yml, /mnt/d/gitspace/smc/SimpleAnnounce/CHANGELOG.md, /mnt/d/gitspace/smc/SimpleAnnounce/CHANGELOG.md] with message: Release version: 1.0.0
Creating tag: release-1.0.0
DRY-RUN: creating tag with name: release-1.0.0
Pushing all to remote: origin
DRY-RUN: pushing to remote: origin
```