### PR TITLE
GH-4: Introduce sound support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- GH-4: Sound support (@tajobe)
 - GH-3: Title type announcement sender (@tajobe)
 - MIT license
 
@@ -13,6 +14,7 @@
 - Config Auto-reload is now a repeating task as intended
 - Config actually created on first run
 - Copy updated default header when config is updated
+- Chat sender advancing the current message per player
 
 ### Removed
 - Offline variant is now the default jar, no longer producing an "online" version

--- a/src/main/kotlin/org/simplemc/simpleannounce/sender/AnnouncementSender.kt
+++ b/src/main/kotlin/org/simplemc/simpleannounce/sender/AnnouncementSender.kt
@@ -4,14 +4,14 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import org.bukkit.plugin.Plugin
-import org.simplemc.simpleannounce.config.SimpleAnnounceConfig
+import org.simplemc.simpleannounce.config.SimpleAnnounceConfig.AnnouncementConfig
 import org.simplemc.simpleannounce.inTicks
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
 
 private val logger = KotlinLogging.logger("SimpleAnnounce AnnouncementSender")
 
-abstract class AnnouncementSender<MessageType, ConfigType : SimpleAnnounceConfig.AnnouncementConfig<MessageType>>(
+abstract class AnnouncementSender<MessageType : AnnouncementConfig.Message, ConfigType : AnnouncementConfig<MessageType>>(
     internal val plugin: Plugin,
     internal val announcement: ConfigType,
 ) : Runnable {
@@ -36,7 +36,15 @@ abstract class AnnouncementSender<MessageType, ConfigType : SimpleAnnounceConfig
         return hasAllRequiredPermissions && hasNoExcludedPermissions
     }
 
-    internal fun getNextAnnouncement(): MessageType = when {
+    internal fun send(message: MessageType, messageAction: (Player) -> Unit) {
+        val sound = message.sound ?: announcement.sound
+        Bukkit.getOnlinePlayers().filterNotNull().filter(this::shouldSendTo).forEach {
+            messageAction(it)
+            sound?.let { sound -> it.playSound(it.location, sound.sound, sound.volume, sound.pitch) }
+        }
+    }
+
+    internal fun getNextMessage(): MessageType = when {
         announcement.messages.size == 1 -> announcement.messages[0]
         announcement.random -> announcement.messages[Random.nextInt(announcement.messages.size)]
         else -> {

--- a/src/main/kotlin/org/simplemc/simpleannounce/sender/BossBarSender.kt
+++ b/src/main/kotlin/org/simplemc/simpleannounce/sender/BossBarSender.kt
@@ -11,7 +11,7 @@ class BossBarSender(
     announcement: Boss,
 ) : AnnouncementSender<Boss.BossBarMessage, Boss>(plugin, announcement) {
     override fun run() {
-        val message = getNextAnnouncement()
+        val message = getNextMessage()
         val barConfig = message.barConfig ?: announcement.barConfig
 
         // create the bar
@@ -19,7 +19,7 @@ class BossBarSender(
         bar.progress = if (barConfig.reverseAnimation) 1.0 else 0.0
 
         // show bar to players
-        Bukkit.getOnlinePlayers().filterNotNull().filter(this::shouldSendTo).forEach(bar::addPlayer)
+        send(message, bar::addPlayer)
         bar.isVisible = true
 
         // set up animation

--- a/src/main/kotlin/org/simplemc/simpleannounce/sender/ChatSender.kt
+++ b/src/main/kotlin/org/simplemc/simpleannounce/sender/ChatSender.kt
@@ -1,17 +1,14 @@
 package org.simplemc.simpleannounce.sender
 
-import org.bukkit.Bukkit
 import org.bukkit.plugin.Plugin
 import org.simplemc.simpleannounce.config.SimpleAnnounceConfig.AnnouncementConfig.Chat
 
 class ChatSender(
     plugin: Plugin,
     announcement: Chat,
-) : AnnouncementSender<String, Chat>(plugin, announcement) {
+) : AnnouncementSender<Chat.ChatMessage, Chat>(plugin, announcement) {
     override fun run() {
-        Bukkit.getOnlinePlayers()
-            .filterNotNull()
-            .filter(this::shouldSendTo)
-            .forEach { it.sendMessage(getNextAnnouncement()) }
+        val message = getNextMessage()
+        send(message) { it.sendMessage(message.message) }
     }
 }

--- a/src/main/kotlin/org/simplemc/simpleannounce/sender/TitleSender.kt
+++ b/src/main/kotlin/org/simplemc/simpleannounce/sender/TitleSender.kt
@@ -1,6 +1,5 @@
 package org.simplemc.simpleannounce.sender
 
-import org.bukkit.Bukkit
 import org.bukkit.plugin.Plugin
 import org.simplemc.simpleannounce.config.SimpleAnnounceConfig.AnnouncementConfig.Title
 
@@ -9,20 +8,17 @@ class TitleSender(
     announcement: Title,
 ) : AnnouncementSender<Title.TitleMessage, Title>(plugin, announcement) {
     override fun run() {
-        val message = getNextAnnouncement()
+        val message = getNextMessage()
         val titleConfig = message.titleConfig ?: announcement.titleConfig
 
-        Bukkit.getOnlinePlayers()
-            .filterNotNull()
-            .filter(this::shouldSendTo)
-            .forEach {
-                it.sendTitle(
-                    message.title,
-                    message.subtitle,
-                    titleConfig.fadeInTicks,
-                    titleConfig.stayTicks,
-                    titleConfig.fadeOutTicks,
-                )
-            }
+        send(message) {
+            it.sendTitle(
+                message.title,
+                message.subtitle,
+                titleConfig.fadeInTicks,
+                titleConfig.stayTicks,
+                titleConfig.fadeOutTicks,
+            )
+        }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,10 @@
 # random(boolean, optional): <if list of messages should be sent in random order>
 # delay(duration, optional - default 0): <Delay to send message>
 # repeat(duration, optional): <time between sending/repeating each message>
+# sound(SoundConfig):
+#   sound(Sound): <Sound to send with announcement, see https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Sound.html)
+#   volume(float, optional): <Volume of sound to send between 0 and 1, default 1>
+#   pitch(float, optional): <Pitch of sound to send between 0.5 and 2, default 1>
 # includesPermissions(String list, optional):
 # - <only send to those with this perm>
 # - <and this one>
@@ -26,7 +30,9 @@
 #
 # Chat type:
 
-# messages(String list): [<list of messages>]
+# messages(ChatMessage list):
+# - message(string): <message string>
+#   <sound config overrides, eg sound, volume, pitch>
 #
 # Boss type:
 #
@@ -37,6 +43,7 @@
 # reverseAnimation(boolean): <if animation should be reversed>
 # messages(BossBarMessage list):
 # - message(string): <message string>
+#   <sound config overrides, eg sound, volume, pitch>
 #   <boss bar config overrides eg hold, color, style, animate, etc...see above>
 #
 # Title type:
@@ -47,6 +54,7 @@
 # messages(TitleMessage list):
 # - title(string): <title string>
 #   subtitle(string): <subtitle string, appears below title slightly smaller>
+#   <sound config overrides, eg sound, volume, pitch>
 #   <title config overrides eg fadeIn, stay, fadeOut...see above>
 #
 # -------------------------
@@ -64,13 +72,19 @@ announcements:
     excludesPermissions:
       - permissions.admin
     messages:
-      - hello
-      - world
+      - message: hello
+      - message: world
   - type: Chat
     repeat: 1m 40s
+    sound:
+      sound: AMBIENT_CAVE
+      volume: .5
+      pitch: 2
     messages:
-      - abc
-      - xyz
+      - message: abc
+        sound:
+          sound: BLOCK_ENCHANTMENT_TABLE_USE
+      - message: xyz
   - type: Title
     repeat: 30s
     messages:


### PR DESCRIPTION
Sounds configurable (sound, volume, pitch) per announcement (across a message group) and per message. Note chat chat messages are no longer a simple string but rather an object (see config.yml updates). No special CHANGELOG entry for this since the current unreleased entry has the entire new config format...I tried for a bit to add a custom deserializer to allow either a simple string or `ChatMessage` object in the list but it really ended up not being worth the complexity. 

...also fixes a bug where each online player would advance the current announcement for chat messages for silly reasons

---

Completes #4 